### PR TITLE
OpenAPI 3.1 compatibility updates.

### DIFF
--- a/lib/Dancer2/Plugin/OpenAPI.pm
+++ b/lib/Dancer2/Plugin/OpenAPI.pm
@@ -245,7 +245,7 @@ sub openapi_path :PluginKeyword {
         $p = \@p;
 
         # set defaults
-        $p = [ map { +{ in => 'query', type => 'string', %$_ } } @$p ];
+        $p = [ map { +{ in => 'query', %$_ } } @$p ];
         
         $arg->{parameters} = $p;
     }

--- a/lib/Dancer2/Plugin/OpenAPI.pm
+++ b/lib/Dancer2/Plugin/OpenAPI.pm
@@ -246,7 +246,11 @@ sub openapi_path :PluginKeyword {
 
         # set defaults
         $p = [ map { +{ in => 'query', %$_ } } @$p ];
-        
+        foreach my $o ( @$p ) {
+            if (! ($o->{type} or $o->{schema})) {
+                $o->{schema} = { type => 'string' };
+            }
+        }
         $arg->{parameters} = $p;
     }
 

--- a/lib/Dancer2/Plugin/OpenAPI/Path.pm
+++ b/lib/Dancer2/Plugin/OpenAPI/Path.pm
@@ -40,6 +40,7 @@ has path => sub {
 has responses => ( predicate => 1);
 
 has description => ( predicate => 1 );
+has operationId => ( predicate => 1 );
 
 has requestBody => ( predicate => 1 );
 
@@ -66,7 +67,7 @@ sub parameter {
 
 sub dancer_pattern_to_swagger_path {
     my $pattern = shift;
-    $pattern =~ s#(?<=/):(\w+)(?=/|$)#{$1}#g;
+    $pattern =~ s#(?<=/):(\w+)\??(?=/|$)#{$1}#g;
     return $pattern;
 }
 
@@ -85,6 +86,7 @@ sub add_to_doc {
     $m->{parameters} = $self->parameters if $self->has_parameters;
     $m->{tags} = $self->tags if $self->has_tags;
     $m->{requestBody} = $self->requestBody if $self->has_requestBody;
+    $m->{operationId} = $self->operationId if $self->has_operationId;
 
     if( $self->has_responses ) {
         $m->{responses} = clone $self->responses;
@@ -139,7 +141,7 @@ sub BUILD {
         $self->parameter( $param => {
             in       => 'path',
             required => JSON::true,
-            type     => "string",
+            schema => { type => 'string' }
         } );
     }
 }

--- a/lib/Dancer2/Plugin/OpenAPI/Path.pm
+++ b/lib/Dancer2/Plugin/OpenAPI/Path.pm
@@ -41,6 +41,8 @@ has responses => ( predicate => 1);
 
 has description => ( predicate => 1 );
 
+has requestBody => ( predicate => 1 );
+
 has parameters => 
     lazy => 1,
     default => sub { [] },
@@ -82,6 +84,7 @@ sub add_to_doc {
     $m->{description} = $self->description if $self->has_description;
     $m->{parameters} = $self->parameters if $self->has_parameters;
     $m->{tags} = $self->tags if $self->has_tags;
+    $m->{requestBody} = $self->requestBody if $self->has_requestBody;
 
     if( $self->has_responses ) {
         $m->{responses} = clone $self->responses;

--- a/lib/Dancer2/Plugin/OpenAPI/Path.pm
+++ b/lib/Dancer2/Plugin/OpenAPI/Path.pm
@@ -89,6 +89,8 @@ sub add_to_doc {
     if( $self->has_responses ) {
         $m->{responses} = clone $self->responses;
 
+=begin1
+        This code is broken and does not generate OpenAPI 3.1 compatible output
         for my $r ( values %{$m->{responses}} ) {
             delete $r->{template};
 
@@ -100,6 +102,7 @@ sub add_to_doc {
                 $r->{examples}{$serializer->content_type} = $example;
             }
         }
+=cut
     }
 
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -54,13 +54,13 @@ $::mech->get_ok( '/openapi_template' );
 
 openapi_path_test '/parameters/standard' => {
     parameters => [
-        { name => 'foo', in => 'query', type => 'string' },
-        { name => 'bar', in => 'query', type => 'string' },
+        { name => 'foo', in => 'query', schema => { type => 'string' } },
+        { name => 'bar', in => 'query', schema => { type => 'string'} },
     ],
 }, sub {
     cmp_deeply $Dancer2::Plugin::OpenAPI::THIS_ACTION->parameters, [
-        { name => 'foo', in => 'query', type => 'string' },
-        { name => 'bar', in => 'query', type => 'string' },
+        { name => 'foo', in => 'query', schema => { type => 'string' } },
+        { name => 'bar', in => 'query', schema => { type => 'string' } },
     ];
 };
 
@@ -84,7 +84,7 @@ openapi_path_test '/parameters/defaults', {
 }, sub {
     cmp_deeply $Dancer2::Plugin::OpenAPI::THIS_ACTION->parameters, [
         { name => 'bar', in => 'query', type => 'string' },
-        { name => 'foo', in => 'query', type => 'string', description => 'FOO' },
+        { name => 'foo', in => 'query', schema => { type => 'string' }, description => 'FOO' },
     ];
 };
 
@@ -96,9 +96,9 @@ openapi_path_test '/parameters/array_with_keys', {
     ],
 }, sub {
     cmp_deeply $Dancer2::Plugin::OpenAPI::THIS_ACTION->parameters, [
-        { name => 'foo', in => 'query', type => 'string', description => 'FOO' },
+        { name => 'foo', in => 'query', schema => { type => 'string' }, description => 'FOO' },
         { name => 'bar', in => 'query', type => 'string' },
-        { name => 'baz', in => 'query', type => 'string' },
+        { name => 'baz', in => 'query', schema => { type => 'string'} },
     ];
 };
 

--- a/t/definition.t
+++ b/t/definition.t
@@ -37,7 +37,7 @@ my $Judge = openapi_definition 'Judge' => {
     }
 };
 
-cmp_deeply $Judge => { '$ref' => '#/definitions/Judge' }, 
+cmp_deeply $Judge => { '$ref' => '#/components/schemas/Judge' },
     "openapi_definition returns shortcut";
 
 openapi_path_test '/definitions' => {


### PR DESCRIPTION

* Fix the location that `openapi_definition` put the schema definition.
* Disable auto content-type injection as it does not currently generate valid schema.
* New targets
   * **openapi_tag** - Allow writing a more detailed tag object to the schema
   * **openapi_security** - Allow defining security constraints
   * **openapi_example** - Allow defining reusable example references.
   * **openapi_response_ref** - Allow defining reusable response references
* Add support for `responseBody` to **openapi_path**
* Documentation fixes to show valid schema objects.